### PR TITLE
Add argon2 crypter

### DIFF
--- a/hash/argon2/argon2.go
+++ b/hash/argon2/argon2.go
@@ -1,0 +1,115 @@
+// Package argon2 implements the argon2 password hashing mechanism, wrapped in
+// the argon2 encoded format.
+package argon2
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+	"gopkg.in/hlandau/passlib.v1/abstract"
+	"gopkg.in/hlandau/passlib.v1/hash/argon2/raw"
+)
+
+// An implementation of Scheme performing argon2 hashing.
+//
+// Uses the recommended values for time, memory and threads defined in raw.
+var Crypter abstract.Scheme
+
+const saltLength = 16
+
+func init() {
+	Crypter = New(
+		raw.RecommendedTime,
+		raw.RecommendedMemory,
+		raw.RecommendedThreads,
+	)
+}
+
+// Returns an implementation of Scheme implementing argon2
+// with the specified parameters.
+func New(time, memory uint32, threads uint8) abstract.Scheme {
+	return &scheme{
+		time:    time,
+		memory:  memory,
+		threads: threads,
+	}
+}
+
+type scheme struct {
+	time, memory uint32
+	threads      uint8
+}
+
+func (c *scheme) SetParams(time, memory uint32, threads uint8) error {
+	c.time = time
+	c.memory = memory
+	c.threads = threads
+	return nil
+}
+
+func (c *scheme) SupportsStub(stub string) bool {
+	return strings.HasPrefix(stub, "$argon2i$")
+}
+
+func (c *scheme) Hash(password string) (string, error) {
+
+	stub, err := c.makeStub()
+	if err != nil {
+		return "", err
+	}
+
+	_, newHash, _, _, _, _, _, err := c.hash(password, stub)
+	return newHash, err
+}
+
+func (c *scheme) Verify(password, hash string) (err error) {
+
+	_, newHash, _, _, _, _, _, err := c.hash(password, hash)
+	if err == nil && !abstract.SecureCompare(hash, newHash) {
+		err = abstract.ErrInvalidPassword
+	}
+
+	return
+}
+
+func (c *scheme) NeedsUpdate(stub string) bool {
+	salt, _, version, time, memory, threads, err := raw.Parse(stub)
+	if err != nil {
+		return false // ...
+	}
+
+	return c.needsUpdate(salt, version, time, memory, threads)
+}
+
+func (c *scheme) needsUpdate(salt []byte, version int, time, memory uint32, threads uint8) bool {
+	return len(salt) < saltLength || version < argon2.Version || time < c.time || memory < c.memory || threads < c.threads
+}
+
+func (c *scheme) hash(password, stub string) (oldHashRaw []byte, newHash string, salt []byte, version int, memory, time uint32, threads uint8, err error) {
+
+	salt, oldHashRaw, version, time, memory, threads, err = raw.Parse(stub)
+	if err != nil {
+		return
+	}
+
+	return oldHashRaw, raw.Argon2(password, salt, time, memory, threads), salt, version, memory, time, threads, nil
+}
+
+func (c *scheme) makeStub() (string, error) {
+	buf := make([]byte, saltLength)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return "", err
+	}
+
+	salt := base64.RawStdEncoding.EncodeToString(buf)
+
+	return fmt.Sprintf("$argon2i$v=%d$m=%d,t=%d,p=%d$%s$", argon2.Version, c.memory, c.time, c.threads, salt), nil
+}
+
+func (c *scheme) String() string {
+	return fmt.Sprintf("argon2(%d,%d,%d,%d)", argon2.Version, c.memory, c.time, c.threads)
+}

--- a/hash/argon2/raw/argon2.go
+++ b/hash/argon2/raw/argon2.go
@@ -1,0 +1,163 @@
+// Package raw provides a raw implementation of the modular-crypt-wrapped scrypt primitive.
+package raw
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/argon2"
+)
+
+// The current recommended time value for interactive logins.
+const RecommendedTime uint32 = 4
+
+// The current recommended memory for interactive logins.
+const RecommendedMemory uint32 = 32 * 1024
+
+// The current recommended number of threads for interactive logins.
+const RecommendedThreads uint8 = 4
+
+// Wrapper for golang.org/x/crypto/argon2 implementing a sensible
+// hashing interface.
+//
+// password should be a UTF-8 plaintext password.
+// salt should be a random salt value in binary form.
+//
+// Time, memory, and threads are parameters to argon2.
+//
+// Returns an argon2 encoded hash.
+func Argon2(password string, salt []byte, time, memory uint32, threads uint8) string {
+
+	passwordb := []byte(password)
+
+	hash := argon2.Key(passwordb, salt, time, memory, threads, 32)
+
+	hstr := base64.RawStdEncoding.EncodeToString(hash)
+	sstr := base64.RawStdEncoding.EncodeToString(salt)
+
+	return fmt.Sprintf("$argon2i$v=%d$m=%d,t=%d,p=%d$%s$%s", argon2.Version, memory, time, threads, sstr, hstr)
+}
+
+// Indicates that a password hash or stub is invalid.
+var ErrInvalidStub = fmt.Errorf("invalid argon2 password stub")
+
+var ErrInvalidKeyValuePair = fmt.Errorf("invalid argon2 key-value pair")
+
+// Parses an argon2 encoded hash.
+//
+// The format is as follows:
+//
+//   $argon2i$v=version$m=memory,t=time,p=threads$salt$hash   // hash
+//   $argon2i$v=version$m=memory,t=time,p=threads$salt        // stub
+//
+func Parse(stub string) (salt, hash []byte, version int, time, memory uint32, threads uint8, err error) {
+	if len(stub) < 26 || !strings.HasPrefix(stub, "$argon2i$") {
+		err = ErrInvalidStub
+		return
+	}
+
+	// $argon2i$  v=version$m=memory,t=time,p=threads$salt-base64$hash-base64
+	parts := strings.Split(stub[9:], "$")
+
+	if len(parts) < 3 {
+		err = ErrInvalidStub
+		return
+	}
+
+	versionParams, err := parseKeyValuePair(parts[0])
+
+	if err != nil {
+		return
+	}
+
+	if len(versionParams) != 1 {
+		err = fmt.Errorf("expected %d version parameters, got %d", 1, len(versionParams))
+		return
+	}
+
+	val, ok := versionParams["v"]
+
+	if !ok {
+		err = errors.New("version (v) parameter is missing")
+		return
+	}
+
+	version = int(val)
+
+	hashParams, err := parseKeyValuePair(parts[1])
+
+	if err != nil {
+		return
+	}
+
+	if len(hashParams) != 3 {
+		err = fmt.Errorf("expected %d hash parameters, got %d", 3, len(hashParams))
+		return
+	}
+
+	val, ok = hashParams["m"]
+
+	if !ok {
+		err = errors.New("memory (m) parameter is missing")
+		return
+	}
+
+	memory = uint32(val)
+
+	val, ok = hashParams["t"]
+
+	if !ok {
+		err = errors.New("time (t) parameter is missing")
+		return
+	}
+
+	time = uint32(val)
+	val, ok = hashParams["p"]
+
+	if !ok {
+		err = errors.New("threads (p) parameter is missing")
+		return
+	}
+
+	threads = uint8(val)
+
+	salt, err = base64.RawStdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return
+	}
+
+	if len(parts) >= 4 {
+		hash, err = base64.RawStdEncoding.DecodeString(parts[3])
+	}
+
+	return
+}
+
+func parseKeyValuePair(pairs string) (result map[string]uint64, err error) {
+
+	result = map[string]uint64{}
+
+	parameterParts := strings.Split(pairs, ",")
+
+	for _, parameter := range parameterParts {
+		parts := strings.Split(parameter, "=")
+
+		if len(parts) != 2 {
+			err = ErrInvalidKeyValuePair
+			return
+		}
+
+		parsedi, err := strconv.ParseUint(parts[1], 10, 32)
+
+		if err != nil {
+			return result, err
+		}
+
+		result[parts[0]] = parsedi
+	}
+
+	return result, nil
+}

--- a/passlib.go
+++ b/passlib.go
@@ -5,7 +5,10 @@
 // and Verify, which uses the default context and sensible defaults.
 package passlib // import "gopkg.in/hlandau/passlib.v1"
 
-import "gopkg.in/hlandau/passlib.v1/abstract"
+import (
+	"gopkg.in/hlandau/passlib.v1/abstract"
+	"gopkg.in/hlandau/passlib.v1/hash/argon2"
+)
 import "gopkg.in/hlandau/passlib.v1/hash/scrypt"
 import "gopkg.in/hlandau/passlib.v1/hash/sha2crypt"
 import "gopkg.in/hlandau/passlib.v1/hash/bcryptsha256"
@@ -23,6 +26,7 @@ var cSuccessfulVerifyCallsDeferringUpgrade = cexp.NewCounter("passlib.ctx.succes
 // hash passwords, and any of the schemes may be used to verify existing
 // passwords. The contents of this value may change with subsequent releases.
 var DefaultSchemes = []abstract.Scheme{
+	argon2.Crypter,
 	scrypt.SHA256Crypter,
 	sha2crypt.Crypter256,
 	sha2crypt.Crypter512,

--- a/passlib_test.go
+++ b/passlib_test.go
@@ -1,11 +1,15 @@
 package passlib
 
-import "testing"
-import "gopkg.in/hlandau/passlib.v1/abstract"
-import "gopkg.in/hlandau/passlib.v1/hash/scrypt"
-import "gopkg.in/hlandau/passlib.v1/hash/sha2crypt"
-import "gopkg.in/hlandau/passlib.v1/hash/bcrypt"
-import "gopkg.in/hlandau/passlib.v1/hash/bcryptsha256"
+import (
+	"testing"
+
+	"gopkg.in/hlandau/passlib.v1/abstract"
+	"gopkg.in/hlandau/passlib.v1/hash/argon2"
+	"gopkg.in/hlandau/passlib.v1/hash/bcrypt"
+	"gopkg.in/hlandau/passlib.v1/hash/bcryptsha256"
+	"gopkg.in/hlandau/passlib.v1/hash/scrypt"
+	"gopkg.in/hlandau/passlib.v1/hash/sha2crypt"
+)
 
 //import "gopkg.in/hlandau/passlib.v1/hash/scrypt"
 
@@ -52,7 +56,7 @@ func TestDefault(t *testing.T) {
 		t.Fatalf("unexpected upgrade")
 	}
 
-	newHash, err = Verify("foobar", "$s2$16384$8$1$qa9lVfhmTE8F2Jpwya9m7uoE$Q7dSPqhZQCLWpjniaz7RVm+xorpSAPTvOCP2uoZmoiI=")
+	newHash, err = Verify("foobar", "$argon2i$v=19$m=32768,t=4,p=4$c29tZXNhbHRzb21lYWxrdA$HcTlbOnOAzJ2dUrlgHnNwC0yallJ/Gl2NbAWqg4IukA")
 	if err != nil {
 		t.Fatalf("err verifying known good: %v", err)
 	}
@@ -91,6 +95,7 @@ func kat(t *testing.T, scheme abstract.Scheme, password, hash string) {
 	c := Context{Schemes: []abstract.Scheme{scheme}}
 
 	_, err := c.Verify(password, hash)
+
 	if err != nil {
 		t.Logf("err verifying known good hash: %v %s %s", scheme, password, hash)
 		t.Fail()
@@ -218,6 +223,13 @@ func TestKat(t *testing.T) {
 		{"foobar", "$s2$16384$8$1$qa9lVfhmTE8F2Jpwya9m7uoE$Q7dSPqhZQCLWpjniaz7RVm+xorpSAPTvOCP2uoZmoiI="},
 	} {
 		kat(t, scrypt.SHA256Crypter, v.p, v.h)
+	}
+
+	for _, v := range []struct{ p, h string }{
+		{"", "$argon2i$v=19$m=32768,t=4,p=4$XEfcwb81UQKSzIcxVEIgrw$1lAPOhgJpGJEgGSKxdnd3n3F9S5qPZSf53iKM1/SvTk"},
+		{"foobar", "$argon2i$v=19$m=32768,t=4,p=4$uN6vgPBb8/liQld8lgFqew$KlvqGCHX7Cap0ohKY7YAUJsbzcnenCwvSAfhqtIA/Q0"},
+	} {
+		kat(t, argon2.Crypter, v.p, v.h)
 	}
 }
 


### PR DESCRIPTION
Adds an argon2 crypter and promote it as the default scheme.

[Argon2](https://github.com/P-H-C/phc-winner-argon2) is the winner of the password hashing competition and is now available in other languages: PHP, Javascript, Ruby etc.

The crypter uses the pure go implementation of argon2 here: https://godoc.org/golang.org/x/crypto/argon2

Closes #4